### PR TITLE
feat(tmux): modernize config with catppuccin and true color

### DIFF
--- a/configs/.tmux.conf
+++ b/configs/.tmux.conf
@@ -54,7 +54,7 @@ set -g status-right "#{catppuccin_session}"
 # Mouse & Input
 # ==============================================================================
 set-option -g mouse on
-set-option -g set-clipboard on
+set-option -g set-clipboard off
 
 # Scroll speed (native, no plugin needed)
 bind -T copy-mode-vi WheelUpPane select-pane \; send-keys -X -N 3 scroll-up
@@ -83,6 +83,7 @@ if-shell "uname | grep -q Darwin" {
   bind-key -T copy-mode-vi v send-keys -X begin-selection
   bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"
   bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
+  bind-key -T root MouseDragEnd1Pane run-shell -b "tmux save-buffer - | pbcopy"
 }
 
 # Linux (auto-detect Wayland/X11)
@@ -91,6 +92,7 @@ if-shell "uname | grep -q Linux" {
   bind-key -T copy-mode-vi v send-keys -X begin-selection
   bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
   bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
+  bind-key -T root MouseDragEnd1Pane run-shell -b "tmux save-buffer - | #{@copy_cmd}"
 }
 
 # ==============================================================================

--- a/configs/.tmux.conf
+++ b/configs/.tmux.conf
@@ -88,7 +88,7 @@ if-shell "uname | grep -q Darwin" {
 
 # Linux (auto-detect Wayland/X11)
 if-shell "uname | grep -q Linux" {
-  set -g @copy_cmd 'if command -v wl-copy >/dev/null; then wl-copy; elif command -v xclip >/dev/null; then xclip -selection clipboard; else tmux display-message "Clipboard utility not found: install wl-copy or xclip"; fi'
+  set -g @copy_cmd 'if command -v wl-copy >/dev/null; then wl-copy; elif command -v xclip >/dev/null; then xclip -selection clipboard; else tmux display-message \"Clipboard utility not found: install wl-copy or xclip\"; fi'
   bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
   bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
   bind-key -T root MouseDragEnd1Pane run-shell -b "tmux save-buffer - | #{@copy_cmd}"

--- a/configs/.tmux.conf
+++ b/configs/.tmux.conf
@@ -2,12 +2,9 @@
 set-environment -g TMUX_PLUGIN_MANAGER_PATH '~/.tmux/plugins'
 
 # ==============================================================================
-# Performance & Core Settings
+# Performance & Core Settings (tmux-sensible handles escape-time, display-time, focus-events)
 # ==============================================================================
-set-option -s escape-time 0
 set-option -g history-limit 50000
-set-option -g display-time 4000
-set-option -g focus-events on
 
 # True color support (modern terminals)
 set-option -g default-terminal "tmux-256color"
@@ -67,9 +64,8 @@ set-option -g default-shell /bin/zsh
 set-window-option -g visual-bell on
 set-window-option -g bell-action other
 
-# Status bar position and refresh
+# Status bar position (tmux-sensible handles status-interval)
 set-option -g status on
-set-option -g status-interval 5
 set-option -g status-position bottom
 set-option -g status-justify centre
 
@@ -83,7 +79,6 @@ bind-key -T copy-mode-vi v send-keys -X begin-selection
 if-shell "uname | grep -q Darwin" {
   bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"
   bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
-  bind-key -T root MouseDragEnd1Pane run-shell -b "tmux save-buffer - | pbcopy"
 }
 
 # Linux (auto-detect Wayland/X11)
@@ -91,7 +86,6 @@ if-shell "uname | grep -q Linux" {
   set-option -g @copy_cmd 'if command -v wl-copy >/dev/null; then wl-copy; elif command -v xclip >/dev/null; then xclip -selection clipboard; else tmux display-message \"Clipboard utility not found: install wl-copy or xclip\"; fi'
   bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
   bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
-  bind-key -T root MouseDragEnd1Pane run-shell -b "tmux save-buffer - | #{@copy_cmd}"
 }
 
 # ==============================================================================

--- a/configs/.tmux.conf
+++ b/configs/.tmux.conf
@@ -48,7 +48,7 @@ set -g @catppuccin_status_connect_separator "no"
 
 # Status bar configuration
 set -g status-left ""
-set -g status-right "#{E:@catppuccin_status_session}"
+set -g status-right "#{catppuccin_session}"
 
 # ==============================================================================
 # Mouse & Input
@@ -85,11 +85,11 @@ if-shell "uname | grep -q Darwin" {
   bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
 }
 
-# Linux (with xclip or wl-copy for Wayland)
+# Linux (auto-detect Wayland/X11)
 if-shell "uname | grep -q Linux" {
   bind-key -T copy-mode-vi v send-keys -X begin-selection
-  bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "xclip -selection clipboard"
-  bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "xclip -selection clipboard"
+  bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel 'if [ -n "$WAYLAND_DISPLAY" ] && command -v wl-copy >/dev/null; then wl-copy; else xclip -selection clipboard; fi'
+  bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel 'if [ -n "$WAYLAND_DISPLAY" ] && command -v wl-copy >/dev/null; then wl-copy; else xclip -selection clipboard; fi'
 }
 
 # ==============================================================================

--- a/configs/.tmux.conf
+++ b/configs/.tmux.conf
@@ -88,7 +88,7 @@ if-shell "uname | grep -q Darwin" {
 
 # Linux (auto-detect Wayland/X11)
 if-shell "uname | grep -q Linux" {
-  set -g @copy_cmd 'if command -v wl-copy >/dev/null; then wl-copy; elif command -v xclip >/dev/null; then xclip -selection clipboard; else true; fi'
+  set -g @copy_cmd 'if command -v wl-copy >/dev/null; then wl-copy; elif command -v xclip >/dev/null; then xclip -selection clipboard; else tmux display-message "Clipboard utility not found: install wl-copy or xclip"; fi'
   bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
   bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
   bind-key -T root MouseDragEnd1Pane run-shell -b "tmux save-buffer - | #{@copy_cmd}"

--- a/configs/.tmux.conf
+++ b/configs/.tmux.conf
@@ -88,7 +88,7 @@ if-shell "uname | grep -q Darwin" {
 
 # Linux (auto-detect Wayland/X11)
 if-shell "uname | grep -q Linux" {
-  set -g @copy_cmd 'if [ -n "$WAYLAND_DISPLAY" ] && command -v wl-copy >/dev/null; then wl-copy; else xclip -selection clipboard; fi'
+  set -g @copy_cmd 'if command -v wl-copy >/dev/null; then wl-copy; elif command -v xclip >/dev/null; then xclip -selection clipboard; else true; fi'
   bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
   bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
   bind-key -T root MouseDragEnd1Pane run-shell -b "tmux save-buffer - | #{@copy_cmd}"

--- a/configs/.tmux.conf
+++ b/configs/.tmux.conf
@@ -11,8 +11,8 @@ set-option -g focus-events on
 
 # True color support (modern terminals)
 set-option -g default-terminal "tmux-256color"
-set-option -sa terminal-features ',xterm-256color:RGB'
-set-option -ga terminal-overrides ',xterm-256color:Tc'
+set-option -sa terminal-features ',*256col*:RGB'
+set-option -ga terminal-overrides ',*256col*:Tc'
 
 # ==============================================================================
 # Plugins (minimal, performance-focused)
@@ -87,9 +87,10 @@ if-shell "uname | grep -q Darwin" {
 
 # Linux (auto-detect Wayland/X11)
 if-shell "uname | grep -q Linux" {
+  set -g @copy_cmd 'if [ -n "$WAYLAND_DISPLAY" ] && command -v wl-copy >/dev/null; then wl-copy; else xclip -selection clipboard; fi'
   bind-key -T copy-mode-vi v send-keys -X begin-selection
-  bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel 'if [ -n "$WAYLAND_DISPLAY" ] && command -v wl-copy >/dev/null; then wl-copy; else xclip -selection clipboard; fi'
-  bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel 'if [ -n "$WAYLAND_DISPLAY" ] && command -v wl-copy >/dev/null; then wl-copy; else xclip -selection clipboard; fi'
+  bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
+  bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
 }
 
 # ==============================================================================
@@ -103,11 +104,11 @@ bind R source-file '~/.tmux.conf' \; display-message "Config reloaded"
 bind | split-window -h -c "#{pane_current_path}"
 bind - split-window -v -c "#{pane_current_path}"
 
-# Vim-style pane navigation
-bind h select-pane -L
-bind j select-pane -D
-bind k select-pane -U
-bind l select-pane -R
+# Vim-style pane navigation (repeatable)
+bind -r h select-pane -L
+bind -r j select-pane -D
+bind -r k select-pane -U
+bind -r l select-pane -R
 
 # Resize panes with Ctrl + hjkl
 bind -r C-h resize-pane -L 5

--- a/configs/.tmux.conf
+++ b/configs/.tmux.conf
@@ -17,38 +17,38 @@ set-option -ga terminal-overrides ',*256col*:Tc'
 # ==============================================================================
 # Plugins (minimal, performance-focused)
 # ==============================================================================
-set -g @plugin 'tmux-plugins/tpm'
-set -g @plugin 'tmux-plugins/tmux-sensible'
-set -g @plugin 'tmux-plugins/tmux-resurrect'
-set -g @plugin 'tmux-plugins/tmux-continuum'
-set -g @plugin 'catppuccin/tmux#v2.1.3'
+set-option -g @plugin 'tmux-plugins/tpm'
+set-option -g @plugin 'tmux-plugins/tmux-sensible'
+set-option -g @plugin 'tmux-plugins/tmux-resurrect'
+set-option -g @plugin 'tmux-plugins/tmux-continuum'
+set-option -g @plugin 'catppuccin/tmux#v2.1.3'
 
 # Continuum settings
-set -g @continuum-restore 'on'
+set-option -g @continuum-restore 'on'
 
 # ==============================================================================
 # Catppuccin Theme Configuration (fast, native implementation)
 # ==============================================================================
-set -g @catppuccin_flavor 'mocha'
-set -g @catppuccin_status_background "none"
+set-option -g @catppuccin_flavor 'mocha'
+set-option -g @catppuccin_status_background "none"
 
 # Window styling
-set -g @catppuccin_window_status_style "rounded"
-set -g @catppuccin_window_number_position "right"
-set -g @catppuccin_window_text " #W"
-set -g @catppuccin_window_current_text " #W"
-set -g @catppuccin_window_flags "icon"
-set -g @catppuccin_window_flags_icon_current " 󰖯"
-set -g @catppuccin_window_flags_icon_last " 󰖰"
+set-option -g @catppuccin_window_status_style "rounded"
+set-option -g @catppuccin_window_number_position "right"
+set-option -g @catppuccin_window_text " #W"
+set-option -g @catppuccin_window_current_text " #W"
+set-option -g @catppuccin_window_flags "icon"
+set-option -g @catppuccin_window_flags_icon_current " 󰖯"
+set-option -g @catppuccin_window_flags_icon_last " 󰖰"
 
 # Status bar modules
-set -g @catppuccin_status_left_separator "█"
-set -g @catppuccin_status_right_separator "█"
-set -g @catppuccin_status_connect_separator "no"
+set-option -g @catppuccin_status_left_separator "█"
+set-option -g @catppuccin_status_right_separator "█"
+set-option -g @catppuccin_status_connect_separator "no"
 
 # Status bar configuration
-set -g status-left ""
-set -g status-right "#{catppuccin_session}"
+set-option -g status-left ""
+set-option -g status-right "#{catppuccin_session}"
 
 # ==============================================================================
 # Mouse & Input
@@ -57,8 +57,8 @@ set-option -g mouse on
 set-option -g set-clipboard off
 
 # Scroll speed (native, no plugin needed)
-bind -T copy-mode-vi WheelUpPane select-pane \; send-keys -X -N 3 scroll-up
-bind -T copy-mode-vi WheelDownPane select-pane \; send-keys -X -N 3 scroll-down
+bind-key -T copy-mode-vi WheelUpPane select-pane \; send-keys -X -N 3 scroll-up
+bind-key -T copy-mode-vi WheelDownPane select-pane \; send-keys -X -N 3 scroll-down
 
 # ==============================================================================
 # Shell & Visual
@@ -76,7 +76,7 @@ set-option -g status-justify centre
 # ==============================================================================
 # Copy Mode (cross-platform clipboard integration)
 # ==============================================================================
-setw -g mode-keys vi
+set-window-option -g mode-keys vi
 bind-key -T copy-mode-vi v send-keys -X begin-selection
 
 # macOS
@@ -88,7 +88,7 @@ if-shell "uname | grep -q Darwin" {
 
 # Linux (auto-detect Wayland/X11)
 if-shell "uname | grep -q Linux" {
-  set -g @copy_cmd 'if command -v wl-copy >/dev/null; then wl-copy; elif command -v xclip >/dev/null; then xclip -selection clipboard; else tmux display-message \"Clipboard utility not found: install wl-copy or xclip\"; fi'
+  set-option -g @copy_cmd 'if command -v wl-copy >/dev/null; then wl-copy; elif command -v xclip >/dev/null; then xclip -selection clipboard; else tmux display-message \"Clipboard utility not found: install wl-copy or xclip\"; fi'
   bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
   bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
   bind-key -T root MouseDragEnd1Pane run-shell -b "tmux save-buffer - | #{@copy_cmd}"
@@ -97,25 +97,25 @@ if-shell "uname | grep -q Linux" {
 # ==============================================================================
 # Key Bindings
 # ==============================================================================
-bind C-p previous-window
-bind C-n next-window
-bind R source-file '~/.tmux.conf' \; display-message "Config reloaded"
+bind-key C-p previous-window
+bind-key C-n next-window
+bind-key R source-file '~/.tmux.conf' \; display-message "Config reloaded"
 
 # Split panes with | and -
-bind | split-window -h -c "#{pane_current_path}"
-bind - split-window -v -c "#{pane_current_path}"
+bind-key | split-window -h -c "#{pane_current_path}"
+bind-key - split-window -v -c "#{pane_current_path}"
 
 # Vim-style pane navigation (repeatable)
-bind -r h select-pane -L
-bind -r j select-pane -D
-bind -r k select-pane -U
-bind -r l select-pane -R
+bind-key -r h select-pane -L
+bind-key -r j select-pane -D
+bind-key -r k select-pane -U
+bind-key -r l select-pane -R
 
 # Resize panes with Ctrl + hjkl
-bind -r C-h resize-pane -L 5
-bind -r C-j resize-pane -D 5
-bind -r C-k resize-pane -U 5
-bind -r C-l resize-pane -R 5
+bind-key -r C-h resize-pane -L 5
+bind-key -r C-j resize-pane -D 5
+bind-key -r C-k resize-pane -U 5
+bind-key -r C-l resize-pane -R 5
 
 # ==============================================================================
 # Initialize TMUX plugin manager (keep this line at the very bottom)

--- a/configs/.tmux.conf
+++ b/configs/.tmux.conf
@@ -78,16 +78,16 @@ bind-key -T copy-mode-vi v send-keys -X begin-selection
 # macOS
 if-shell "uname | grep -q Darwin" {
   set-option -g @copy_cmd "pbcopy"
-  bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
-  bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
 }
 
 # Linux (auto-detect Wayland/X11)
 if-shell "uname | grep -q Linux" {
   set-option -g @copy_cmd 'if command -v wl-copy >/dev/null; then wl-copy; elif command -v xclip >/dev/null; then xclip -selection clipboard; else tmux display-message \"Clipboard utility not found: install wl-copy or xclip\"; fi'
-  bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
-  bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
 }
+
+# Bind keys to use the OS-specific copy command
+bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
+bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
 
 # ==============================================================================
 # Key Bindings

--- a/configs/.tmux.conf
+++ b/configs/.tmux.conf
@@ -77,8 +77,9 @@ bind-key -T copy-mode-vi v send-keys -X begin-selection
 
 # macOS
 if-shell "uname | grep -q Darwin" {
-  bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"
-  bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
+  set-option -g @copy_cmd "pbcopy"
+  bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
+  bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
 }
 
 # Linux (auto-detect Wayland/X11)

--- a/configs/.tmux.conf
+++ b/configs/.tmux.conf
@@ -11,7 +11,7 @@ set-option -g focus-events on
 
 # True color support (modern terminals)
 set-option -g default-terminal "tmux-256color"
-set-option -sa terminal-features ',*256col*:RGB'
+set-option -ga terminal-features ',*256col*:RGB'
 set-option -ga terminal-overrides ',*256col*:Tc'
 
 # ==============================================================================

--- a/configs/.tmux.conf
+++ b/configs/.tmux.conf
@@ -77,10 +77,10 @@ set-option -g status-justify centre
 # Copy Mode (cross-platform clipboard integration)
 # ==============================================================================
 setw -g mode-keys vi
+bind-key -T copy-mode-vi v send-keys -X begin-selection
 
 # macOS
 if-shell "uname | grep -q Darwin" {
-  bind-key -T copy-mode-vi v send-keys -X begin-selection
   bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"
   bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
   bind-key -T root MouseDragEnd1Pane run-shell -b "tmux save-buffer - | pbcopy"
@@ -89,7 +89,6 @@ if-shell "uname | grep -q Darwin" {
 # Linux (auto-detect Wayland/X11)
 if-shell "uname | grep -q Linux" {
   set -g @copy_cmd 'if [ -n "$WAYLAND_DISPLAY" ] && command -v wl-copy >/dev/null; then wl-copy; else xclip -selection clipboard; fi'
-  bind-key -T copy-mode-vi v send-keys -X begin-selection
   bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
   bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
   bind-key -T root MouseDragEnd1Pane run-shell -b "tmux save-buffer - | #{@copy_cmd}"

--- a/configs/.tmux.conf
+++ b/configs/.tmux.conf
@@ -1,54 +1,121 @@
 # TPM Plugin Manager Path
 set-environment -g TMUX_PLUGIN_MANAGER_PATH '~/.tmux/plugins'
 
-# List of plugins
-set -g @plugin 'tmux-plugins/tpm'
-set -g @plugin 'tmux-plugins/tmux-sensible'
-set -g @plugin 'tmux-plugins/tmux-cpu'
-set -g @plugin 'tmux-plugins/tmux-sidebar'
-set -g @plugin 'tmux-plugins/tmux-resurrect'
-set -g @plugin 'tmux-plugins/tmux-continuum'
-set -g @plugin 'nhdaly/tmux-better-mouse-mode'
-set -g @plugin 'erikw/tmux-powerline'
-
-# Default options
+# ==============================================================================
+# Performance & Core Settings
+# ==============================================================================
 set-option -s escape-time 0
 set-option -g history-limit 50000
 set-option -g display-time 4000
-set-option -g default-terminal "screen-256color"
 set-option -g focus-events on
 
-set-option -g status on
-set-option -g status-fg colour255
-set-option -g status-interval 2
-set-option -g status-justify "centre"
-set-option -g status-left-length 60
-set-option -g status-right-length 90
-set -g @scroll-speed-num-lines-per-scroll 1
+# True color support (modern terminals)
+set-option -g default-terminal "tmux-256color"
+set-option -sa terminal-features ',xterm-256color:RGB'
+set-option -ga terminal-overrides ',xterm-256color:Tc'
+
+# ==============================================================================
+# Plugins (minimal, performance-focused)
+# ==============================================================================
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-sensible'
+set -g @plugin 'tmux-plugins/tmux-resurrect'
+set -g @plugin 'tmux-plugins/tmux-continuum'
+set -g @plugin 'catppuccin/tmux#v2.1.3'
+
+# Continuum settings
 set -g @continuum-restore 'on'
 
-set-option -g default-shell /bin/zsh
+# ==============================================================================
+# Catppuccin Theme Configuration (fast, native implementation)
+# ==============================================================================
+set -g @catppuccin_flavor 'mocha'
+set -g @catppuccin_status_background "none"
+
+# Window styling
+set -g @catppuccin_window_status_style "rounded"
+set -g @catppuccin_window_number_position "right"
+set -g @catppuccin_window_text " #W"
+set -g @catppuccin_window_current_text " #W"
+set -g @catppuccin_window_flags "icon"
+set -g @catppuccin_window_flags_icon_current " 󰖯"
+set -g @catppuccin_window_flags_icon_last " 󰖰"
+
+# Status bar modules
+set -g @catppuccin_status_left_separator "█"
+set -g @catppuccin_status_right_separator "█"
+set -g @catppuccin_status_connect_separator "no"
+
+# Status bar configuration
+set -g status-left ""
+set -g status-right "#{E:@catppuccin_status_session}"
+
+# ==============================================================================
+# Mouse & Input
+# ==============================================================================
 set-option -g mouse on
 set-option -g set-clipboard on
+
+# Scroll speed (native, no plugin needed)
+bind -T copy-mode-vi WheelUpPane select-pane \; send-keys -X -N 3 scroll-up
+bind -T copy-mode-vi WheelDownPane select-pane \; send-keys -X -N 3 scroll-down
+
+# ==============================================================================
+# Shell & Visual
+# ==============================================================================
+set-option -g default-shell /bin/zsh
 set-window-option -g visual-bell on
 set-window-option -g bell-action other
-set-window-option -g window-status-current-format "#[fg=colour235, bg=colour27]⮀#[fg=colour255, bg=colour27] #I ⮁ #W #[fg=colour27, bg=colour235]⮀"
 
-# Copy mode settings (cross-platform clipboard integration)
+# Status bar position and refresh
+set-option -g status on
+set-option -g status-interval 5
+set-option -g status-position bottom
+set-option -g status-justify centre
+
+# ==============================================================================
+# Copy Mode (cross-platform clipboard integration)
+# ==============================================================================
+setw -g mode-keys vi
+
+# macOS
 if-shell "uname | grep -q Darwin" {
+  bind-key -T copy-mode-vi v send-keys -X begin-selection
+  bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"
   bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
-  bind-key -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
-}
-if-shell "uname | grep -q Linux" {
-  bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "xclip -selection clipboard"
-  bind-key -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "xclip -selection clipboard"
 }
 
-# Key binding
+# Linux (with xclip or wl-copy for Wayland)
+if-shell "uname | grep -q Linux" {
+  bind-key -T copy-mode-vi v send-keys -X begin-selection
+  bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "xclip -selection clipboard"
+  bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "xclip -selection clipboard"
+}
+
+# ==============================================================================
+# Key Bindings
+# ==============================================================================
 bind C-p previous-window
 bind C-n next-window
-bind R source-file '~/.tmux.conf'
+bind R source-file '~/.tmux.conf' \; display-message "Config reloaded"
 
-# Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
+# Split panes with | and -
+bind | split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
+
+# Vim-style pane navigation
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+
+# Resize panes with Ctrl + hjkl
+bind -r C-h resize-pane -L 5
+bind -r C-j resize-pane -D 5
+bind -r C-k resize-pane -U 5
+bind -r C-l resize-pane -R 5
+
+# ==============================================================================
+# Initialize TMUX plugin manager (keep this line at the very bottom)
+# ==============================================================================
 run -b '~/.tmux/plugins/tpm/tpm'
-

--- a/configs/.zshrc
+++ b/configs/.zshrc
@@ -297,18 +297,17 @@ fi
 
 [[ -f "$HOME/.local/bin/env" ]] && . "$HOME/.local/bin/env"
 
-# opencode
-export PATH=/Users/jiun/.opencode/bin:$PATH
-
-# opencode
-export PATH=/Users/june/.opencode/bin:$PATH
-
-# bun completions
-[ -s "/Users/june/.bun/_bun" ] && source "/Users/june/.bun/_bun"
-
-# bun
+################################
+# Bun
 export BUN_INSTALL="$HOME/.bun"
-export PATH="$BUN_INSTALL/bin:$PATH"
+[[ -d "$BUN_INSTALL" ]] && {
+  export PATH="$BUN_INSTALL/bin:$PATH"
+  [[ -s "$BUN_INSTALL/_bun" ]] && source "$BUN_INSTALL/_bun"
+}
+
+################################
+# OpenCode
+[[ -d "$HOME/.opencode/bin" ]] && export PATH="$HOME/.opencode/bin:$PATH"
 
 ################################
 # hishtory (better shell history)


### PR DESCRIPTION
## Summary
- Replace slow Python-based `tmux-powerline` with native `catppuccin/tmux` theme for faster status bar rendering
- Add true color (24-bit) support for modern terminal compatibility
- Remove unused plugins and add vim-style keybindings for improved workflow

## Changes

### Theme & Performance
| Item | Before | After |
|------|--------|-------|
| Theme | `tmux-powerline` (Python) | `catppuccin/tmux` (native) |
| Terminal | `screen-256color` | `tmux-256color` + True color |
| Status interval | 2s | 5s |
| Plugin count | 7 | 4 |

### Removed Plugins
- `tmux-plugins/tmux-cpu`
- `tmux-plugins/tmux-sidebar`
- `nhdaly/tmux-better-mouse-mode`
- `erikw/tmux-powerline`

### Added Features
- True color (24-bit RGB) support
- Vim-style pane navigation (`h/j/k/l`)
- Intuitive split bindings (`|` and `-`)
- Improved vi-mode copy (`v` to select, `y` to copy)
- Pane resize with `C-h/j/k/l`

## Test plan
- [ ] Run `tmux source ~/.tmux.conf`
- [ ] Install new plugins with `prefix + I`
- [ ] Verify catppuccin theme renders correctly
- [ ] Test true color with `printf "\x1b[38;2;255;100;0mTRUECOLOR\x1b[0m\n"`
- [ ] Test vim-style pane navigation
- [ ] Clean up old plugins: `rm -rf ~/.tmux/plugins/{tmux-powerline,tmux-cpu,tmux-sidebar,tmux-better-mouse-mode}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)